### PR TITLE
fix: create types for `WorkspacePodTemplateMutate` and adjust camelCase leftovers

### DIFF
--- a/workspaces/frontend/src/app/hooks/useCreateWorkspace.ts
+++ b/workspaces/frontend/src/app/hooks/useCreateWorkspace.ts
@@ -23,7 +23,7 @@ const useCreateWorkspace = (
       if (!namespace) {
         return Promise.reject(new Error('namespace is not available yet'));
       }
-      return createWorkspaceCall(opts, api, namespace, formData).then((result) => result.workspace);
+      return createWorkspaceCall(opts, api, formData, namespace).then((result) => result.workspace);
     },
     [api, apiAvailable, namespace, formData],
   );

--- a/workspaces/frontend/src/app/types.ts
+++ b/workspaces/frontend/src/app/types.ts
@@ -1,5 +1,5 @@
 import { APIOptions } from '~/shared/api/types';
-import { Workspace, WorkspaceKind } from '~/shared/types';
+import { Workspace, WorkspaceKind, WorkspacePodTemplateMutate } from '~/shared/types';
 
 export type ResponseBody<T> = {
   data: T;
@@ -79,31 +79,12 @@ export type NotebookAPIs = {
   createWorkspace: CreateWorkspace;
 };
 
-export type PodTemplate = {
-  pod_metadata: {
-    labels: Record<string, string>;
-    annotations: Record<string, string>;
-  };
-  volumes: {
-    home: string;
-    data: {
-      pvc_name: string;
-      mount_path: string;
-      read_only: boolean;
-    }[];
-  };
-  options: {
-    image_config: string;
-    pod_config: string;
-  };
-};
-
 export type CreateWorkspaceData = {
   data: {
     name: string;
     kind: string;
     paused: boolean;
-    defer_updates: boolean;
-    pod_template: PodTemplate;
+    deferUpdates: boolean;
+    podTemplate: WorkspacePodTemplateMutate;
   };
 };

--- a/workspaces/frontend/src/shared/types.ts
+++ b/workspaces/frontend/src/shared/types.ts
@@ -95,6 +95,33 @@ export interface WorkspaceStatus {
   stateMessage: string;
 }
 
+export interface WorkspacePodMetadataMutate {
+  labels: Record<string, string>;
+  annotations: Record<string, string>;
+}
+
+export interface WorkspacePodVolumeMount {
+  pvcName: string;
+  mountPath: string;
+  readOnly?: boolean;
+}
+
+export interface WorkspacePodVolumesMutate {
+  home?: string;
+  data: WorkspacePodVolumeMount[];
+}
+
+export interface WorkspacePodTemplateOptionsMutate {
+  imageConfig: string;
+  podConfig: string;
+}
+
+export interface WorkspacePodTemplateMutate {
+  podMetadata: WorkspacePodMetadataMutate;
+  volumes: WorkspacePodVolumesMutate;
+  options: WorkspacePodTemplateOptionsMutate;
+}
+
 export interface Workspace {
   name: string;
   namespace: string;


### PR DESCRIPTION
Types for `WorkspacePodTemplateMutate` follow: https://github.com/kubeflow/notebooks/blob/notebooks-v2/workspaces/backend/internal/models/workspaces/types_create.go#L34